### PR TITLE
New indicators of height gain

### DIFF
--- a/src/main/java/fatalflare/elytrapitch/ModConfig.java
+++ b/src/main/java/fatalflare/elytrapitch/ModConfig.java
@@ -39,6 +39,14 @@ class ModConfig implements ConfigData {
     boolean showDurabilityFP = false;
     @ConfigEntry.Category("FP")
     boolean showElytraItemFP = false;
+    @ConfigEntry.Category("FP")
+    boolean showLastApexGain = true;
+    @ConfigEntry.Category("FP")
+    boolean showOverallGain = false;
+    @ConfigEntry.Category("FP")
+    boolean showLastApexHeight = false;
+    @ConfigEntry.Category("FP")
+    boolean advancedStatsInNewLine = false;
 
     // Third Person Settings
     @ConfigEntry.Category("TP")


### PR DESCRIPTION
I have stumbled upon this mod and wanted to use it for practicing the flight just using the HUD elements.
I was missing an indicator that shows me if i lost height or gained it from the last Apex i flew to the one that i am at right now.
A nice to have feature would also be an indicator of overall height gained from take of however there are a few problems with the current implementation:
- boosting with rockets does not reset the starting height to the last apex AFTER the rocket boost
- boosting with an entity cram/elytra launcher also does not reset

The last apex is considered the last height where the `oldYVelocity > 0 && yVelocity < 0`

Also added coloring, so small tweaks to the displayString needed to be made, final processing is now as a `MutableText` however none of your string concatination was touched. Just a simple conversion at the end.

Added the following new config options:
- `showLastApexGain = false`
- `showOverallGain = false`
- `showLastApexHeight = false`
- `advancedStatsInNewLine = false`

![grafik](https://github.com/user-attachments/assets/d67e661b-eec1-4212-9277-263573920596)
This is how it looks without a new line, last apex height was `207`, i gained `+3` blocks with the last apex, overall gain from starting point is now `+15` blocks

![grafik](https://github.com/user-attachments/assets/c156f02d-f045-47bc-a24f-f36c81e17a0c)
This is with a new line, i lost `-6` blocks overall but with the latest apex i gained `+10` (my personal best wtf? .-.)